### PR TITLE
	Added support for nargs, turning them into arrays

### DIFF
--- a/argparse.bash
+++ b/argparse.bash
@@ -34,13 +34,12 @@ EOF
     cat >> "$argparser"
 
     cat >> "$argparser" <<EOF
-import types
 args = parser.parse_args()
 for arg in [a for a in dir(args) if not a.startswith('_')]:
     value = getattr(args, arg, None)
     if value is None:
         value = ''
-    if type(value) == types.ListType:
+    if type(value) is list:
         print('{0}=({1});'.format(arg.upper(), " ".join(map(lambda s: '"%s"' % s, value))))
     else:
         print('{0}="{1}";'.format(arg.upper(), value))

--- a/argparse.bash
+++ b/argparse.bash
@@ -34,12 +34,16 @@ EOF
     cat >> "$argparser"
 
     cat >> "$argparser" <<EOF
+import types
 args = parser.parse_args()
 for arg in [a for a in dir(args) if not a.startswith('_')]:
     value = getattr(args, arg, None)
     if value is None:
         value = ''
-    print('{0}="{1}";'.format(arg.upper(), value))
+    if type(value) == types.ListType:
+        print('{0}=({1});'.format(arg.upper(), " ".join(map(lambda s: '"%s"' % s, value))))
+    else:
+        print('{0}="{1}";'.format(arg.upper(), value))
 EOF
 
     # Define variables corresponding to the options if the args can be

--- a/example-nargs.sh
+++ b/example-nargs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source $(dirname $0)/argparse.bash || exit 1
+argparse "$@" <<EOF || exit 1
+parser.add_argument('infile')
+parser.add_argument('outfile')
+parser.add_argument('-n', '--not-required', nargs='+',
+                    help='optional multi value argument [default %(default)s]')
+EOF
+
+echo required infile: "$INFILE"
+echo required outfile: "$OUTFILE"
+echo optional: 
+for a in "${NOT_REQUIRED[@]}"
+do
+    echo "  $a"
+done


### PR DESCRIPTION
This change has worked for me, allowing me to use `nargs` with your very handy argparse-bash.

```
$ ./example-nargs.sh infile.txt "name with spaces.txt" -n one "twenty two" three
required infile: infile.txt
required outfile: name with spaces.txt
optional:
  one
  twenty two
  three
```