### PR TITLE
Preserve newlines in description string of `ArgumentParser`

### DIFF
--- a/argparse.bash
+++ b/argparse.bash
@@ -28,6 +28,8 @@ class MyArgumentParser(argparse.ArgumentParser):
         sys.exit(1)
 
 parser = MyArgumentParser(prog=os.path.basename("$0"),
+            # preserve newlines in description
+            formatter_class=argparse.RawDescriptionHelpFormatter,
             description="""$ARGPARSE_DESCRIPTION""")
 EOF
 


### PR DESCRIPTION
This PR adds support for multiline description passed to `ArgumentParser`.

By default, argparse wraps the description text (i.e. replaces newlines with spaces).

To preserve newlines, I added the `formatter_class` option to `ArgumentParser`. See docs: https://docs.python.org/3/library/argparse.html?highlight=rawtexthelpformatter#argparse.RawDescriptionHelpFormatter

Thank you for this cool utility!